### PR TITLE
Suppress warning that we suspect isn't necessary

### DIFF
--- a/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Buffering.swift
+++ b/AudioKit/Common/Nodes/Playback/Players/Player/AKPlayer+Buffering.swift
@@ -41,7 +41,7 @@ extension AKPlayer {
         }
 
         if !updateNeeded {
-            AKLog("No buffer update needed")
+            //AKLog("No buffer update needed")
             return
         }
 


### PR DESCRIPTION
Our app logs contain this warning on playing existing sounds -- seems unnecessary (unless we're doing something wrong)

*REPLACE ALL OF THIS TEXT WITH A DESCRIPTION OF YOUR CODE CHANGES*

Ready to send us a pull request? Please make sure your request is based on the [develop](https://github.com/audiokit/AudioKit/tree/develop) branch of the repository as `master` only holds stable releases.
